### PR TITLE
Update version date.

### DIFF
--- a/asterisk/main/asterisk.c
+++ b/asterisk/main/asterisk.c
@@ -139,7 +139,7 @@ int daemon(int, int);  /* defined in libresolv of all places */
 /*! \brief Welcome message when starting a CLI interface */
 #define WELCOME_MESSAGE \
         ast_verbose("\n"); \
-	ast_verbose("AllStarLink Asterisk Version 2.0.0-beta 03/24/2021 "ASTERISK_VERSION"\n"); \
+	ast_verbose("AllStarLink Asterisk Version 2.0.0-beta 11/30/2022 "ASTERISK_VERSION"\n"); \
         ast_verbose("Copyright (C) 1999 - 2018 Digium, Inc. Jim Dixon and others\n"); \
     ast_verbose("Copyright (C) 2018-2021 AllStarLink Inc.\n"); \
 	ast_verbose("Created by Mark Spencer <markster@digium.com>\n"); \


### PR DESCRIPTION
Turns out there is a version date in asterisk.c as well as app_rpt.c. 
<pre>
rep -r --include="*.c" "2.0.0-beta"
asterisk/main/asterisk.c:	ast_verbose("AllStarLink Asterisk Version 2.0.0-beta 11/30/2022 "ASTERISK_VERSION"\n"); \
asterisk/apps/app_rpt.c:static  char *tdesc = "Radio Repeater / Remote Base  version 2.0.0-beta 11/30/2022";
</pre>

The one in asterisk.c shows on the console with verbose -rvvv. 

<pre>
asterisk -rvvv
AllStarLink Asterisk Version 2.0.0-beta 11/30/2022 GIT 19d8e48
Copyright (C) 1999 - 2018 Digium, Inc. Jim Dixon and others
Copyright (C) 2018-2021 AllStarLink Inc.
Created by Mark Spencer <markster@digium.com>
Asterisk comes with ABSOLUTELY NO WARRANTY; type 'core show warranty' for details.
This is free software, with components licensed under the GNU General Public
License version 2 and other licenses; you are welcome to redistribute it under
certain conditions. Type 'core show license' for details.
=========================================================================
Connected to Asterisk GIT 19d8e48 currently running on ASLbeta7-10 (pid = 21021)
Verbosity is at least 3
</pre>