### PR TITLE
Fix linker library flags for native armhf builds of asterisk

### DIFF
--- a/asterisk/main/Makefile
+++ b/asterisk/main/Makefile
@@ -48,7 +48,7 @@ else
   endif
 endif
 
-ifneq ($(findstring $(OSARCH), linux-gnu uclinux linux-uclibc linux-gnueabi ),)
+ifneq ($(findstring $(OSARCH), linux-gnu uclinux linux-uclibc linux-gnueabi linux-gnueabihf ),)
   ifneq ($(findstring LOADABLE_MODULES,$(MENUSELECT_CFLAGS)),)
   AST_LIBS+=-ldl
   endif


### PR DESCRIPTION
See community discussion here: https://community.allstarlink.org/t/asl-2-0-beta-6-bugs-discussion/19793
The changes to config.guess and config.sub are now outputting linux-gnueabihf as the architecture instead of linux-gnueabi, for Raspberry pi builds. This causes the Makefile for main/asterisk to not calculate the correct library flags for linking. This edit allows native builds of the source code to work again.