### PR TITLE
fix crash when large number of nodes are connected

### DIFF
--- a/asterisk/apps/app_rpt.c
+++ b/asterisk/apps/app_rpt.c
@@ -7201,8 +7201,7 @@ static int rpt_do_lstats(int fd, int argc, char *argv[])
 
 static int rpt_do_xnode(int fd, int argc, char *argv[])
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;
@@ -7441,8 +7440,7 @@ static int rpt_do_xnode(int fd, int argc, char *argv[])
 
 static int rpt_do_nodes(int fd, int argc, char *argv[])
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	if(argc != 3)
@@ -24826,8 +24824,7 @@ static int rpt_manager_do_sawstat(struct mansession *ses, const struct message *
 
 static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m, char *str)
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;


### PR DESCRIPTION
This will fix the crash occurring when a large number of nodes are connected (directly or indirectly). issue [#9](https://github.com/AllStarLink/ASL-Asterisk/issues/9). ns should be of type int and not char. ns will return an invalid value above 127 due to the char data type (-128 to 127), this will result in a crash on qsort function. This is the answer why the ARM architecture is immune to this bug : On x86 systems char is generally signed (-128 to 127). On arm systems it is generally unsigned (0 to 255).