### PR TITLE
Added missing build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,45 @@ apt update
 
 * Install apt dependencies
 ```
-apt -y install quilt libreadline-gplv2-dev libgsm1-dev libssl-dev libasound2-dev libpq-dev \
-  unixodbc-dev libpri-dev libvpb-dev asl-dahdi-source libnewt-dev libsqlite-dev libspeex-dev \
-  libspeexdsp-dev libcurl4-openssl-dev libpopt-dev libiksemel-dev freetds-dev libvorbis-dev \
-  libsnmp-dev libcap-dev libi2c-dev libjansson-dev build-essential libtonezone-dev \
-  git cmake g++ libboost-all-dev libgmp-dev swig python3-numpy libusb-dev
+apt -y install \
+  asl-dahdi-source \
+  build-essential \
+  cmake \
+  devscripts \
+  doxygen \
+  freetds-dev \
+  g++ \
+  git \
+  graphviz \
+  gsfonts \
+  libasound2-dev \
+  libboost-all-dev \
+  libcap-dev \
+  libcurl4-openssl-dev \
+  libgmp-dev \
+  libgsm1-dev \
+  libi2c-dev \
+  libiksemel-dev \
+  libjansson-dev \
+  libnewt-dev \
+  libpopt-dev \
+  libpq-dev \
+  libpri-dev \
+  libreadline-gplv2-dev \
+  libsnmp-dev \
+  libspeex-dev \
+  libspeexdsp-dev \
+  libsqlite-dev \
+  libssl-dev \
+  libtonezone-dev \
+  libusb-dev \
+  libvorbis-dev \
+  libvpb-dev \
+  python3-numpy \
+  quilt \
+  swig \
+  unixodbc-dev
+
 ```
 
 ## Compiling


### PR DESCRIPTION
On a minimal installation of Debian (Docker: debian:buster-slim) the following packages are required to build:

* devscripts
* doxygen
* graphviz
* gsfonts

To better track which packages are needed, I've also sorted the list alphabetically.

Note that I've only added to this list, not checked to see if all packages are required. If I spot any surplus packages I'll add a separate pull request.