### PR TITLE
Update say.c for issues with time announcement in French

### DIFF
--- a/asterisk/main/say.c
+++ b/asterisk/main/say.c
@@ -5746,9 +5746,11 @@ int ast_say_time_fr(struct ast_channel *chan, time_t t, const char *ints, const 
 	res = ast_say_number(chan, tm.tm_hour, ints, lang, "f");
 	if (!res)
 		res = ast_streamfile(chan, "digits/oclock", lang);
+	if (!res)
+		res = ast_waitstream(chan, ints);
 	if (tm.tm_min) {
 		if (!res)
-		res = ast_say_number(chan, tm.tm_min, ints, lang, (char *) NULL);
+		res = ast_say_number(chan, tm.tm_min, ints, lang, "f");
 	}
 	return res;
 }


### PR DESCRIPTION
This updates say.c so that it will say the oclock audio file properly in French.  This corrects #58.

This updates say.c to change use feminine for the time.  This corrects #61.

This changes were proposed by Patrick/TK5EP.