### PR TITLE
chan_echolink: Should not free frame used in ast_dsp_process

### DIFF
--- a/asterisk/channels/chan_echolink.c
+++ b/asterisk/channels/chan_echolink.c
@@ -1702,7 +1702,6 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			{
 				f2 = ast_translate(p->xpath,&fr,0);
 				f1 = ast_dsp_process(NULL,p->dsp,f2);
-				ast_frfree(f2);
 #ifdef	OLD_ASTERISK
 				if (f1->frametype == AST_FRAME_DTMF)
 #else

--- a/asterisk/channels/chan_echolink.c
+++ b/asterisk/channels/chan_echolink.c
@@ -1719,6 +1719,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 						x = 1;
 					}
 				}
+				ast_frfree(f1);
 			} 
 			if (!x) ast_queue_frame(ast,&fr);
 		}


### PR DESCRIPTION
This corrects a problem with chan_echolink freeing a frame that was freed by the ast_dsp_process.  This closes #67.