### PR TITLE
Fix missing comma in the 818 macro

### DIFF
--- a/allstar/configs/beagleboard/rpt.conf
+++ b/allstar/configs/beagleboard/rpt.conf
@@ -295,7 +295,7 @@ startup_macro =
 815 = ilink,15			; Full system status (all nodes)
 816 = ilink,16			; Reconnect links disconnected with "disconnect all links"
 817 = ilink,17			; MDC test (for diag purposes)
-818 = ilink 18			; Permanently Connect specified link -- local monitor only
+818 = ilink,18			; Permanently Connect specified link -- local monitor only
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/allstar/configs/pi/rpt.conf
+++ b/allstar/configs/pi/rpt.conf
@@ -295,7 +295,7 @@ startup_macro =
 815 = ilink,15			; Full system status (all nodes)
 816 = ilink,16			; Reconnect links disconnected with "disconnect all links"
 817 = ilink,17			; MDC test (for diag purposes)
-818 = ilink 18			; Permanently Connect specified link -- local monitor only
+818 = ilink,18			; Permanently Connect specified link -- local monitor only
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/allstar/configs/simpleusb/rpt.conf
+++ b/allstar/configs/simpleusb/rpt.conf
@@ -295,7 +295,7 @@ startup_macro =
 815 = ilink,15			; Full system status (all nodes)
 816 = ilink,16			; Reconnect links disconnected with "disconnect all links"
 817 = ilink,17			; MDC test (for diag purposes)
-818 = ilink 18			; Permanently Connect specified link -- local monitor only
+818 = ilink,18			; Permanently Connect specified link -- local monitor only
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/allstar/configs/usbradio/rpt.conf
+++ b/allstar/configs/usbradio/rpt.conf
@@ -295,7 +295,7 @@ startup_macro =
 815 = ilink,15			; Full system status (all nodes)
 816 = ilink,16			; Reconnect links disconnected with "disconnect all links"
 817 = ilink,17			; MDC test (for diag purposes)
-818 = ilink 18			; Permanently Connect specified link -- local monitor only
+818 = ilink,18			; Permanently Connect specified link -- local monitor only
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/asterisk/configs/rpt.conf.sample
+++ b/asterisk/configs/rpt.conf.sample
@@ -302,7 +302,7 @@ statpost_url = http://stats.allstarlink.org/uhandler ; Status updates
 815 = ilink,15			; Full system status (all nodes)
 816 = ilink,16			; Reconnect links disconnected with "disconnect all links"
 817 = ilink,17			; MDC test (for diag purposes)
-818 = ilink 18			; Permanently Connect specified link -- local monitor only
+818 = ilink,18			; Permanently Connect specified link -- local monitor only
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Setting up an ASL system and reading through the saved rpt.conf file I saw that the comma was missing in the 818 macro.  Looking at the file histories it appears the comma was missing in commit add4bd615d.