### PR TITLE
Add RPT_ALINKS and RPT_NUMALINKS to init routine

### DIFF
--- a/asterisk/apps/app_rpt.c
+++ b/asterisk/apps/app_rpt.c
@@ -19826,6 +19826,9 @@ char tmpstr[512],lstr[MAXLINKLIST],lat[100],lon[100],elev[100];
 	rpt_update_boolean(myrpt,"RPT_AUTOPATCHUP",-1);
 	rpt_update_boolean(myrpt,"RPT_NUMLINKS",-1);
 	rpt_update_boolean(myrpt,"RPT_LINKS",-1);
+	rpt_update_boolean(myrpt,"RPT_ALINKS",-1);
+	rpt_update_boolean(myrpt,"RPT_NUMALINKS",-1);
+
 	myrpt->ready = 1;	
 	while (ms >= 0)
 	{


### PR DESCRIPTION
RPT_ALINKS and RPT_NUMALINKS are not initialized at startup.  Once a remote node connects/disconnects the vars become available.  Until a connection, MANY errors to be logged like this: 
```WARNING[627] ast_expr2.fl: ast_yyerror():  syntax error: syntax error, unexpected '='TILDE, expecting $end; Input:```
when using an event test for remote adjacent nodes as found in https://wiki.allstarlink.org/wiki/Event_Management

Simply adding the vars at startup (just like RPT_LINKS and RPT_NUMLINKS) addresses the issue.
