### PR TITLE
Address segfault while loading modules: Don't use while to dlclose(lib)

### DIFF
--- a/asterisk/main/loader.c
+++ b/asterisk/main/loader.c
@@ -199,7 +199,7 @@ void __ast_module_user_remove(struct ast_module *mod, struct ast_module_user *u)
 	AST_LIST_REMOVE(&mod->users, u, entry);
 	AST_LIST_UNLOCK(&mod->users);
 	ast_atomic_fetchadd_int(&mod->usecount, -1);
-  		free(u);
+	free(u);
 
 	ast_update_use_count();
 }

--- a/asterisk/main/loader.c
+++ b/asterisk/main/loader.c
@@ -336,8 +336,8 @@ static void unload_dynamic_module(struct ast_module *mod)
 
 static struct ast_module *load_dynamic_module(const char *resource_in, unsigned int global_symbols_only)
 {
-	char fn[4097] = "";
-	void *lib = NULL;
+	char fn[4097];
+	void *lib;
 	struct ast_module *mod;
 	char *resource = (char *) resource_in;
 	unsigned int wants_global;
@@ -358,7 +358,7 @@ static struct ast_module *load_dynamic_module(const char *resource_in, unsigned 
 		return NULL;
 
 	strcpy(resource_being_loaded->resource, resource);
-	
+
 	if (!(lib = dlopen(fn, RTLD_LAZY | RTLD_LOCAL))) {
 		ast_log(LOG_WARNING, "Error loading module '%s': %s\n", resource_in, dlerror());
 		free(resource_being_loaded);


### PR DESCRIPTION
After much struggling with random seg faults in the module loading on several machines, I finally had a 32 bit machine that faulted 99.999% of the time allowing me to figure out the culprit (with GDB).  After some research, the Asterisk team had already figure it out:
https://github.com/asterisk/asterisk/commit/e9fc32105353a65b89f546008ca98ffadf359704
https://issues-archive.asterisk.org/ASTERISK-22538
This 100% solved the segfault while loading modules on my 32 bit machine.

